### PR TITLE
Fixing error on install (#705 on nicholasmr/obblm, #17 here)

### DIFF
--- a/header.php
+++ b/header.php
@@ -156,12 +156,12 @@ else {
     setupGlobalVars(T_SETUP_GLOBAL_VARS__COMMON);
     require_once('modules/modsheader.php'); # Registration of modules.
     setupGlobalVars(T_SETUP_GLOBAL_VARS__POST_LOAD_MODULES);
+	
+	/******************************
+	   Translate skills globally
+	******************************/
+	global $lng;
+	$lng->TranslateSkills();
 }
-
-/******************************
-   Translate skills globally
-******************************/
-global $lng;
-$lng->TranslateSkills();
 
 


### PR DESCRIPTION
There is an error in header.php when installing, caused because the translations object $lng hasn't been created in this workflow. It's created in setupGlobalVars(T_SETUP_GLOBAL_VARS__POST_LOAD_MODULES), which isn't called because of the if (defined('T_NO_STARTUP')) conditional.

This commit move the translations call inside the else part of the conditional, which prevents the error and doesn't seem to cause any problems. :)