### PR TITLE
The alternative scheduler module currently doesn't load

### DIFF
--- a/settings_modules.php
+++ b/settings_modules.php
@@ -26,7 +26,7 @@ $settings['modules_enabled'] = array(
     'XML_BOTOCS'         => false, # BOTOCS XML export of team
     'LeagueTables'       => true, # Provides league table link on the main menu
     'Conference'         => true, # Provides support for conferences within tournaments
-    'Scheduler'          => true, # Alternative match scheduler
+    'Scheduler'          => false, # Alternative match scheduler
     'LeaguePref'         => true, # Allows dynamic configuration of league preferences
     'TeamCreator'        => true, # Allows coaches to create teams quickly
 );


### PR DESCRIPTION
Should probably be disabled by default in new installs.