### PR TITLE
#62 Now able to open match dialog in non-Chrome browsers

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -8,6 +8,10 @@
         font-size: 12px;
     }
     
+    table td.date {
+        width: 65px;
+    }
+    
     div.row {
         margin-bottom: 2px;
     }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -86,6 +86,10 @@
     #MatchDialog input[type="number"] {
         width: 2.5em;
     }
+    
+    #MatchDialog #TreasuryChange {
+        width: 4em;
+    }
             
     .may-buy-new-skill {
         background-color: rgba(0,255,0,0.25);

--- a/js/app/ViewModel/MatchDialogViewModel.js
+++ b/js/app/ViewModel/MatchDialogViewModel.js
@@ -122,7 +122,8 @@ var MatchDialogViewModel = function(playersOnSelectedTeam) {
             url: 'match_webservice.php',
             data: data,
             success: function() {
-                self.close();
+                // reload page so updates are made
+                window.location.href = window.location.href;
             }
         });
     };

--- a/js/app/ViewModel/MobileViewModel.js
+++ b/js/app/ViewModel/MobileViewModel.js
@@ -1,5 +1,14 @@
 var MobileViewModel = function(playersOnSelectedTeam, matches) {
     var self = this;
+                        
+    // Matches come from the database as "30000", but we deal with them as "30". Convert before we do anything else.
+    _.each(matches, function(match) {
+        match.income1 /= 1000;        
+        match.income2 /= 1000;
+        match.gate /= 1000;
+        match.tv1 /= 1000;
+        match.tv2 /= 1000;
+    });
     
     self.openPlayerDialog = function(playerViewModel, event) {
         var playerId = playerViewModel.id;
@@ -16,17 +25,7 @@ var MobileViewModel = function(playersOnSelectedTeam, matches) {
         var match = _.find(matches, function(match) {
             return match.match_id === matchId;
         });
-        
-        // These values are loaded from the database as "10000", but saved as "10" so we convert before displaying.
-        // This condition is a bit of a hack -- incomes are only higher than 100 if they are "10,000" format, so we haven't converted anything yet.
-        if(match.income1 > 100) {
-            match.income1 /= 1000;        
-            match.income2 /= 1000;
-            match.gate /= 1000;
-            match.tv1 /= 1000;
-            match.tv2 /= 1000;
-        }
-        
+
         self.matchDialogViewModel.match(match);
         // opens after AJAX call in MatchDialogViewModel
     }

--- a/js/app/ViewModel/MobileViewModel.js
+++ b/js/app/ViewModel/MobileViewModel.js
@@ -11,7 +11,7 @@ var MobileViewModel = function(playersOnSelectedTeam, matches) {
         $('#PlayerDialog').dialog({modal: true});
     };
     
-    self.openMatchDialog = function() {
+    self.openMatchDialog = function(playerViewModel, event) {
         var matchId = $(event.target).attr('data-match-id');
         var match = _.find(matches, function(match) {
             return match.match_id === matchId;

--- a/lib/class_mobile_htmlout.php
+++ b/lib/class_mobile_htmlout.php
@@ -76,9 +76,6 @@ class Mobile_HTMLOUT {
                         }
                     ?>
                 </select>
-                <span>
-                    <?php echo 'TV' . $selectedTeam->tv/1000 . ', ' . $selectedTeam->treasury/1000 . 'k, FF' . $selectedTeam->rg_ff; ?> 
-                </span>
                 <span class="button-panel">
 					<img id="open-menu" src="images/menu.svg" alt="Menu" class="icon ui-button ui-state-default ui-corner-all" data-bind="click: showMenu" />
 					<ul id="menu" class="ui-state-default ui-corner-left ui-corner-left ui-corner-br" data-bind="visible: isMenuVisible">
@@ -88,6 +85,10 @@ class Mobile_HTMLOUT {
 					</ul>
                 </span>
             </form>
+            <div>
+                <?php echo 'TV' . $selectedTeam->tv/1000 . ', ' . $selectedTeam->treasury/1000 . 'k, FF' . $selectedTeam->rg_ff; ?> 
+                <?php if($selectedTeam->apothecary) { echo ', ' . $lng->getTrn('common/apothecary'); } ?>
+            </div>
             <div id="tabs">
                 <ul>
                     <li><a href="#Teams"><?php echo $lng->getTrn('common/team'); ?></a></li>

--- a/lib/class_mobile_htmlout.php
+++ b/lib/class_mobile_htmlout.php
@@ -272,13 +272,13 @@ class Mobile_HTMLOUT {
             </div>
             <div class="row">
                 <span class="label"><?php echo $lng->getTrn('matches/report/treas'); ?>:</span>
-                <input type="number" data-bind="value: treasuryChange" />k
+                <input type="number" id="TreasuryChange" data-bind="value: treasuryChange" />k
             </div>
-            <div class="treasury-change-field row">
+            <div class="row">
                 <span class="label"><?php echo $lng->getTrn('matches/report/ff'); ?>:</span>
-                <span>1<input type="radio" name="TreasuryChange" data-bind="checked: fanFactorChange" value="1" /></span>
-                <span>0<input type="radio" name="TreasuryChange" data-bind="checked: fanFactorChange" value="0" /></span>
-                <span>-1<input type="radio" name="TreasuryChange" data-bind="checked: fanFactorChange" value="-1" /></span>
+                <span>1<input type="radio" name="FanFactorChange" data-bind="checked: fanFactorChange" value="1" /></span>
+                <span>0<input type="radio" name="FanFactorChange" data-bind="checked: fanFactorChange" value="0" /></span>
+                <span>-1<input type="radio" name="FanFactorChange" data-bind="checked: fanFactorChange" value="-1" /></span>
             </div>
         </fieldset>
         

--- a/lib/class_mobile_htmlout.php
+++ b/lib/class_mobile_htmlout.php
@@ -95,7 +95,7 @@ class Mobile_HTMLOUT {
                     <li><a href="#Games"><?php echo $lng->getTrn('menu/matches_menu/name'); ?></a></li>
                 </ul>
                 <?php Mobile_HTMLOUT::teamSummaryView($playersOnSelectedTeam); ?>
-                <?php Mobile_HTMLOUT::matchSummaryView($allMatches); ?>
+                <?php Mobile_HTMLOUT::matchSummaryView($recentMatches, $upcomingMatches); ?>
             </div>
         </div>
         <?php   
@@ -165,25 +165,29 @@ class Mobile_HTMLOUT {
         <?php
     }
     
-    private static function matchSummaryView($allMatches) {
+    private static function outputMatchesRows($matches) {
+        foreach($matches as $match) {
+            $dateCreated = date('Y-m-d', strtotime($match->date_created));
+            
+            echo '<tr>';
+            echo '<td class="date"><a data-bind="click: openMatchDialog" href="#" data-match-id="' . $match->match_id . '">' . $dateCreated . '</td>';
+            echo '<td class="team-name">' . $match->team1_name . '</td>';
+            echo '<td>v.</td>';
+            echo '<td class="team-name">' . $match->team2_name . '</td>';
+            echo '</tr>';
+        }
+    }
+    
+    private static function matchSummaryView($recentMatches, $upcomingMatches) {
         global $lng;
         ?>
         <div id="Games">
-            <div><?php echo $lng->getTrn('profile/team/games'); ?></div>
             <table id="GamesTable">
                 <tbody>
-                <?php
-                    foreach($allMatches as $match) {
-                        $dateCreated = date('Y-m-d', strtotime($match->date_created));
-                        
-                        echo '<tr>';
-                        echo '<td class="date"><a data-bind="click: openMatchDialog" href="#" data-match-id="' . $match->match_id . '">' . $dateCreated . '</td>';
-                        echo '<td class="team-name">' . $match->team1_name . '</td>';
-                        echo '<td>v.</td>';
-                        echo '<td class="team-name">' . $match->team2_name . '</td>';
-                        echo '</tr>';
-                    }
-                ?>
+                    <tr><td colspan="4"><h3><?php echo $lng->getTrn("common/recentmatches"); ?></h3></td></tr>
+                    <?php Mobile_HTMLOUT::outputMatchesRows($recentMatches); ?>
+                    <tr><td colspan="4"><h3><?php echo $lng->getTrn("common/upcomingmatches"); ?></h3></td></tr>
+                    <?php Mobile_HTMLOUT::outputMatchesRows($upcomingMatches); ?>
                 </tbody>
             </table>
             <div>


### PR DESCRIPTION
Fixed an error in the method signature for opening the match dialog that was preventing it opening in Firefox, at least. No idea why Chrome worked, it really shouldn't have.

Also added text saying that the player has an apothecary to the team page. Because my brand new human team just bought one. :P

Added: *January 14th*

* Refreshing tables after save match
* Separating upcoming and recent matches
* Trying something to fix treasury update issue
* Making the date column fixed width