### PR TITLE
Michael team specific treasuries

### DIFF
--- a/localsettings/settings_new_league_template.php
+++ b/localsettings/settings_new_league_template.php
@@ -47,7 +47,7 @@ $rules['player_refund']         = 0;        // Player sell value percentage. Def
 $rules['journeymen_limit']      = 11;       // Until a team can field this number of players, it may fill team positions with journeymen.
 $rules['post_game_ff']          = false;    // Default is false. Allows teams to buy and drop fan factor even though their first game has been played.
 
-$rules['initial_treasury']      = 1100000;  // Default is 1000000.
+$rules['initial_treasury']      = 1000000;  // Default is 1000000.
 $rules['initial_rerolls']       = 0;        // Default is 0.
 $rules['initial_fan_factor']    = 0;        // Default is 0.
 $rules['initial_ass_coaches']   = 0;        // Default is 0.
@@ -58,6 +58,36 @@ $rules['max_rerolls']           = -1;       // Default is -1.
 $rules['max_fan_factor']        = 9;        // Default is 9.
 $rules['max_ass_coaches']       = -1;       // Default is -1.
 $rules['max_cheerleaders']      = -1;       // Default is -1.
+
+// Remove double backslashes in front of team number to enable team specific starting treasuries.
+$rules['initial_team_treasury'] = array(	//	0			=>	1000000,	// Amazon
+											//	1			=>	1000000,	// Chaos
+											//	2			=>	1000000,	// Chaos Dwarf
+											//	3			=>	1000000,	// Dark Elf
+											//	4			=>	1000000,	// Dwarf
+											//	5			=>	1000000,	// Elf
+											//	6			=>	1000000,	// Goblin
+											//	7			=>	1000000,	// Halfling
+											//	8			=>	1000000,	// High Elf
+											//	9			=>	1000000,	// Human
+											//	10			=>	1000000,	// Khemri
+											//	11			=>	1000000,	// Lizardman
+											//	12			=>	1000000,	// Orc
+											//	13			=>	1000000,	// Necromantic
+											//	14			=>	1000000,	// Norse
+											//	15			=>	1000000,	// Nurgle
+											//	16			=>	1000000,	// Ogre
+											//	17			=>	1000000,	// undead
+											//	18			=>	1000000,	// Vampire
+											//	19			=>	1000000,	// Skaven
+											//	20			=>	1000000,	// Wood Elf
+											//	21			=>	1000000,	// Chaos Pact
+											//	22			=>	1000000,	// Slann
+											//	23			=>	1000000,	// Underworld
+											//	24			=>	1000000,	// Bretonnia
+											//	25			=>	1000000,	// Daemons of Khorne
+											//	26			=>	1000000,	// Apes of Wrath
+										);	
 
 /*********************
  *   Standings pages

--- a/modules/teamcreator/class_team_creator.php
+++ b/modules/teamcreator/class_team_creator.php
@@ -230,7 +230,7 @@ public static function handlePost($cid) {
       status(false, $lng->getTrn('notallowed', 'TeamCreator'));
       return;
    }
-
+   
    $lid_did = $_POST['lid_did'];
    @list($lid,$did) = explode(',',$_POST['lid_did']);
    setupGlobalVars(T_SETUP_GLOBAL_VARS__LOAD_LEAGUE_SETTINGS, array('lid' => (int) $lid)); // Load correct $rules for league.
@@ -247,7 +247,12 @@ public static function handlePost($cid) {
    $fans = $_POST['qtyo1'];
    $cl = $_POST['qtyo2'];
    $ac = $_POST['qtyo3'];   
-   $treasury = $race['treasury'];
+   if (array_key_exists($rid, $rules['initial_team_treasury'])) {
+        $init_treasury = $rules['initial_team_treasury'][$rid];
+	  } else {
+		$init_treasury = $rules['initial_treasury'];
+      };
+   $treasury = $init_treasury;
    $treasury -= $rerolls * $race['other']['rr_cost'];
    $treasury -= $fans * 10000;
    $treasury -= $cl * 10000;
@@ -291,7 +296,7 @@ public static function handlePost($cid) {
    /* Enforce league rules and common BB ones */
    $errors = array();
    if ($treasury < 0) {
-      $errors[] = $lng->getTrn('tooExpensive', 'TeamCreator') . ' (' . $race['treasury']/1000 . ' kGP)';
+      $errors[] = $lng->getTrn('tooExpensive', 'TeamCreator') . ' (' . $init_treasury/1000 . ' kGP)';
    }
    if (sizeof($players) < 11) {
       $errors[] = $lng->getTrn('tooFewPlayers', 'TeamCreator');
@@ -374,7 +379,7 @@ EOQ;
 echo<<< EOQ
       var lid = document.getElementById('lid_did');
       for (var i = 0; i < lid.options.length; i++) {
-         if (lid.options[i].value==$post->lid_did) {
+         if (lid.options[i].value=="$post->lid_did") {
             lid.selectedIndex = i;
             break;
          }
@@ -702,6 +707,7 @@ EOQ;
    $txtDollar = $lng->getTrn('dollar', 'TeamCreator');
    $txtQuantity = $lng->getTrn('quantity', 'TeamCreator');
    $txtSubtotal = $lng->getTrn('subtotal', 'TeamCreator');
+   
 
 echo<<< EOQ
        <td align="right" id="indTxt">$txtInducements:</td>

--- a/modules/teamcreator/class_team_creator.php
+++ b/modules/teamcreator/class_team_creator.php
@@ -356,7 +356,9 @@ public static function handlePost($cid) {
    /* Report errors and reset the form, or redirect to the team page */
    if (sizeof($errors) > 0) {
       $msg = implode(",<br />", $errors);
-      status(false, $msg);
+	  if ($_POST['action'] == 'create') {
+		status(false, $msg); // Don't show error messages if there was no attempt to create team
+	  }
       $post = (object) $_POST;
 echo<<< EOQ
    <script type="text/javascript">
@@ -652,6 +654,14 @@ echo<<< EOQ
       }
 
    }
+   
+   function changeLeague() {
+      // Reload page with new league rules when League dropdown changes
+	  // Set action field to 'leagueChange' for $_POST handling
+	  document.getElementById("action").value = 'leagueChange';
+	  // Submit form
+	  document.getElementById("form_team").submit();
+   }
 
    </script>
    <form method="POST" id="form_team">
@@ -675,7 +685,7 @@ EOQ;
          $lgeDiv = $lng->getTrn('common/league') . '/' . $lng->getTrn('common/division');
 echo<<< EOQ
       <td align="right"><b>$txtTeamName</b>:</td><td><input type="text" id="tname" name="tname" size="20" maxlength="50"></td>
-      <td align="right"><b>$lgeDiv</b>:</td><td><select name="lid_did" id="lid_did">
+      <td align="right"><b>$lgeDiv</b>:</td><td><select name="lid_did" id="lid_did" onChange="changeLeague()">
 EOQ;
          foreach ($leagues = Coach::allowedNodeAccess(Coach::NODE_STRUCT__TREE, $coach->coach_id, array(T_NODE_LEAGUE => array('tie_teams' => 'tie_teams'))) as $lid => $lstruct) {
             if ($lstruct['desc']['tie_teams']) {

--- a/modules/teamcreator/class_team_creator.php
+++ b/modules/teamcreator/class_team_creator.php
@@ -291,7 +291,7 @@ public static function handlePost($cid) {
    /* Enforce league rules and common BB ones */
    $errors = array();
    if ($treasury < 0) {
-      $errors[] = $lng->getTrn('tooExpensive', 'TeamCreator') . ' (' . $initTreasury/1000 . ' kGP)';
+      $errors[] = $lng->getTrn('tooExpensive', 'TeamCreator') . ' (' . $race['treasury']/1000 . ' kGP)';
    }
    if (sizeof($players) < 11) {
       $errors[] = $lng->getTrn('tooFewPlayers', 'TeamCreator');
@@ -553,7 +553,6 @@ echo<<< EOQ
       setText("total", "0");
 	  setText("total", '0/' + maximum.toString());
       document.getElementById("raceid").value = race.rid;
-	  document.getElementById("initTreasury").value = race.treasury;
 
       rowIdx = 0;
       for (i = 0; i < race["player_count"]; i++) {
@@ -651,9 +650,8 @@ echo<<< EOQ
 
    </script>
    <form method="POST" id="form_team">
-   <input  id="action" name="action" value="create" />
-   <input  id="raceid" name="raceid" value="" />
-   <input  id="initTreasury" name="initTreasury" value="" />
+   <input type="hidden" id="action" name="action" value="create" />
+   <input type="hidden" id="raceid" name="raceid" value="" />
    <div class='boxWide'>
       <table class="common"><tr><td>
       <b>$txtRaceSelectTitle</b>: <select id="rid" name="rid" onchange="changeRace(this.options[this.selectedIndex].value)">


### PR DESCRIPTION
I've made some changes to the TeamCreator module and the settings_X.php file to support individual team treasuries. Where these are not used or enabled, it will default to the league treasury value.
I've also fixed a couple of bugs in the TeamCreator module:
- Changes to the League dropdown did not reload the league rules, so teams were being created using the rules of the first league in the dropdown
- On page reload, the league select dropdown was reverting to the first in the list
