### PR TITLE
Workaround: create teams for another coach when admin/commissioner

### DIFF
--- a/css/stylesheet_default.css
+++ b/css/stylesheet_default.css
@@ -252,7 +252,7 @@ ul.css3menu1 a:active, ul.css3menu1 a:focus{
 ul.css3menu1 a{
     display:block;vertical-align:middle;text-align:left;text-decoration:none;font:bold 12px Arial,Helvetica,sans-serif;color:#000000;text-shadow:#FFF 0 0 1px;cursor:pointer;padding:4px 10px 4px 10px;background-color:#c1c1c1;background-image:url("../images/mainbk.png");background-repeat:repeat;background-position:0 0;border-width:0 0 0 1px;border-style:solid;border-color:#C0C0C0;}
 ul.css3menu1 ul li{
-    float:none;margin:10px 0 0;}
+    float:none;margin:7px 0 0;}
 ul.css3menu1 ul a{
     text-align:left;padding:4px;background-color:#FFFFFF;background-image:none;border-width:0;border-radius:0px;-moz-border-radius:0px;-webkit-border-radius:0px;font:bold 12px Arial,Helvetica,sans-serif;color:#000;text-decoration:none;}
 ul.css3menu1 li:hover>a,ul.css3menu1 li a.pressed{

--- a/install.php
+++ b/install.php
@@ -27,7 +27,7 @@ require('header.php'); // Includes and constants.
 HTMLOUT::frame_begin(false,false);
 title('OBBLM setup');
 
-if (isset($_POST['setup']) || $argv[1] == 'setup') {
+if (isset($_POST['setup']) || (isset($argv[1]) ? $argv[1] == 'setup' : false)) {
     $setupOK = setup_database();
     if ($setupOK) {
         echo "<br><b><font color='green'>Finished</font></b>";
@@ -79,4 +79,3 @@ EOL;
    }
 }
 HTMLOUT::frame_end();
-?>

--- a/lang/translations.xml
+++ b/lang/translations.xml
@@ -364,6 +364,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
             <extra_skills>Manage extra player skills</extra_skills>
             <ach_skills>Remove ach. player skills</ach_skills>
             <ff>Manage team fan factor</ff>
+            <removeNiggle>Remove player niggle</removeNiggle>
 
             <desc>
                 <unhire_journeyman> <![CDATA[ Regret permanently hiring a journeyman.<br> This only works on players from a 0-16 allowed position on your team's roster. ]]> </unhire_journeyman>
@@ -375,6 +376,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
                 <extra_skills> <![CDATA[ Manage a player's extra skills. ]]> </extra_skills>
                 <ach_skills> <![CDATA[ Remove a players achieved skills. This makes the player able to rechoose a skill. ]]> </ach_skills>
                 <ff> <![CDATA[ Make changes to team's fan factor .]]> </ff>
+                <removeNiggle> <![CDATA[ Remove one of a players niggling injuries.]]> </removeNiggle>
             </desc>
         </box_admin>
     </team>

--- a/lang/translations.xml
+++ b/lang/translations.xml
@@ -588,6 +588,8 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
   <looney>Looney</looney>
   <fanatic>Fanatic</fanatic>
   <troll>Troll</troll>
+  <deathdiver>Death Diver</deathdiver>
+  <ooligan>'Ooligan</ooligan>
 
   <halfling>Halfling</halfling>
   <treeman>Treeman</treeman>
@@ -730,6 +732,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
   <throwteammate>Throw Team-Mate</throwteammate>
   <titchy>Titchy</titchy>
   <wildanimal>Wild Animal</wildanimal>
+  <swoop>Swoop</swoop>
 </skill>
 
 <starplayer>
@@ -2230,6 +2233,15 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
         <dead>Mort</dead>
         <sold>Vendu</sold>
         <bought>Acheté</bought>
+		<ma>Mv</ma>
+		<st>F</st>
+		<ag>Ag</ag>
+		<av>Ar</av>
+		<english>Anglais</english>
+		<spanish>Espagnol</spanish>
+		<german>Allemand</german>
+		<french>Français</french>
+		<italian>Italien</italian>
         <td>Touchdowns</td>
         <intcpt>Interceptions</intcpt>
         <cp>Réussites</cp>
@@ -2576,6 +2588,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
         <goblinrenegade>Renégat Gobelin</goblinrenegade>
         <skavenrenegade>Renégat Skaven</skavenrenegade>
         <darkelfrenegade>Renégat Elfe Noir</darkelfrenegade>
+		<orcrenegade>Renégat Orc</orcrenegade>
         <chaostroll>Troll du Chaos</chaostroll>
         <chaosogre>Ogre du Chaos</chaosogre>
         <necromanticwerewolf>Loup-Garou nécromantique</necromanticwerewolf>
@@ -2597,6 +2610,8 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
         <looney>Fanatique</looney>
         <fanatic>Fanatique</fanatic>
         <troll>Troll</troll>
+		<deathdiver>Plongeur de la mort</deathdiver>
+		<oligan>'Ooligan</oligan>
         <halfling>Halfling</halfling>
         <treeman>Homme-arbre</treeman>
         <ogre>Ogre</ogre>
@@ -2714,6 +2729,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
     <throwteammate>Lancer un Coéquipier</throwteammate>
     <titchy>Microbe</titchy>
     <wildanimal>Animal Sauvage</wildanimal>
+    <swoop>Planeur</swoop>
 </skill>
 
 <starplayer>
@@ -2785,7 +2801,7 @@ For example, english is in <en-GB>, french in <fr-FR>, .......
   <monday>Lundi</monday>
   <tuesday>Mardi</tuesday>
   <wednesday>Mercredi</wednesday>
-  <thursday>Jeudi></thursday>
+  <thursday>Jeudi</thursday>
   <friday>Vendredi</friday>
   <saturday>Samedi</saturday>
   <sunday>Dimanche</sunday>

--- a/lib/class_coach_htmlout.php
+++ b/lib/class_coach_htmlout.php
@@ -145,7 +145,10 @@ private function _menu($ALLOW_EDIT)
         <li><a href="<?php echo $url.'&amp;subsec=recentmatches';?>"><?php echo $lng->getTrn('common/recentmatches');?></a></li>
         <?php
         if ($ALLOW_EDIT) {
-            ?><li><a href="handler.php?type=teamcreator"><?php echo $lng->getTrn('cc/new_team');?></a></li><?php
+//<li><a href="handler.php?type=teamcreator"><?php echo $lng->getTrn('cc/new_team');?></a></li>
+            ?>
+        <li><a href="<?php echo $url.'&amp;subsec=newteam';?>"><?php echo $lng->getTrn('cc/new_team');?></a></li>
+<?php
         }
         if (Module::isRegistered('SGraph')) {
             echo "<li><a href='handler.php?type=graph&amp;gtype=".SG_T_COACH."&amp;id=$this->coach_id'>Vis. stats</a></li>\n";

--- a/lib/class_player.php
+++ b/lib/class_player.php
@@ -440,6 +440,15 @@ class Player
             return false;
         }        
     }
+    
+    public function removeNiggle() {
+        if ($this->is_journeyman || $this->is_sold || $this->is_dead)
+            return false;
+
+        $query = "UPDATE players SET inj_ni = GREATEST(inj_ni - 1, 0) WHERE player_id = $this->player_id";
+        
+        return mysql_query($query);
+    }
 
     public function rename($new_name) {
         return mysql_query("UPDATE players SET name = '" . mysql_real_escape_string($new_name) . "' WHERE player_id = $this->player_id");

--- a/lib/class_team_htmlout.php
+++ b/lib/class_team_htmlout.php
@@ -299,6 +299,7 @@ public function handleActions($ALLOW_EDIT)
                 status($team->setff_bought($_POST['amount']));
                 SQLTriggers::run(T_SQLTRIG_TEAM_DPROPS, array('obj' => T_OBJ_TEAM, 'id' => $team->team_id));
                 break;
+            case 'removeNiggle': status($p->removeNiggle()); break;
         }
     }
 
@@ -1034,6 +1035,7 @@ private function _actionBoxes($ALLOW_EDIT, $players)
                         'extra_skills'      => $lng->getTrn($base.'/box_admin/extra_skills'),
                         'ach_skills'        => $lng->getTrn($base.'/box_admin/ach_skills'),
                         'ff'                => $lng->getTrn($base.'/box_admin/ff'),
+                        'removeNiggle'      => $lng->getTrn($base.'/box_admin/removeNiggle'),
                     );
 
                     // Set default choice.
@@ -1307,6 +1309,31 @@ private function _actionBoxes($ALLOW_EDIT, $players)
                                 ?>
                                 </select>
                                 <input type="hidden" name="type" value="ach_skills">
+                                <?php
+                                break;
+                                
+                            /***************
+                             * Remove niggling injuries
+                             **************/
+
+                            case 'removeNiggle':
+                                echo $lng->getTrn('profile/team/box_admin/desc/removeNiggle');
+                                ?>
+                                <hr><br>
+                                <?php echo $lng->getTrn('common/player');?>:<br>
+                                <select name="player">
+                                <?php
+                                $DISABLE = true;
+                                foreach ($players as $p) {
+                                    if ($p->is_sold || $p->is_dead || $p->is_journeyman || $p->inj_ni == 0)
+                                        continue;
+
+                                    echo "<option value='$p->player_id'>$p->nr $p->name</option>\n";
+                                    $DISABLE = false;
+                                }
+                                ?>
+                                </select>
+                                <input type="hidden" name="type" value="removeNiggle">
                                 <?php
                                 break;
                         }

--- a/lib/game_data_bb16.php
+++ b/lib/game_data_bb16.php
@@ -24,10 +24,54 @@ require_once('lib/game_data_lrb6.php');
 $skillarray['E'][114] = $skillididx[114] = 'Monstrous Mouth';
 $skillarray['E'][115] = $skillididx[115] = 'Timmmber';
 $skillarray['E'][116] = $skillididx[116] = 'Weeping Blades';
+$skillarray['E'][117] = $skillididx[117] = 'Swoop';
+
 // Changes to present teams/positionals from LRB6 to BB16.
 $DEA['Human']['players']['Catcher']['cost'] = 60000;
 $DEA['Skaven']['players']['Gutter Runner']['def'] = array (23, 116);
 $DEA['Halfling']['players']['Treeman']['def'] = array (54, 57, 58, 109, 59, 110, 115);
+
+$DEA['Goblin']['players']['deathdiver'] = array (
+	'ma'        	=> 6,
+	'st'        	=> 2,
+	'ag'        	=> 3,
+	'av'        	=> 7,
+	'def'	    => array (104, 108, 117 ),
+	'norm'		=> array ('A'),
+	'doub'		=> array ('G', 'S', 'P'),
+	'qty'			=> 1,
+	'cost'			=> 60000,
+	'icon'			=> 'goblin1',
+	'pos_id'        => 235,
+);
+$DEA['Goblin']['players']['ooligan'] = array (
+	'ma'        	=> 6,
+	'st'        	=> 2,
+	'ag'        	=> 3,
+	'av'        	=> 7,
+	'def'	    => array (104, 23, 108, 72, 97 ),
+	'norm'		=> array ('A'),
+	'doub'		=> array ('G', 'S', 'P'),
+	'qty'			=> 1,
+	'cost'			=> 70000,
+	'icon'			=> 'goblin1',
+	'pos_id'        => 236,
+);
+
+$DEA['Chaos Pact']['players']['Orc Renegade'] = array (
+    'ma'        	=> 5,
+	'st'        	=> 3,
+	'ag'        	=> 3,
+	'av'        	=> 9,
+	'def'	    => array (113),
+	'norm'		=> array ('G', 'M'),
+	'doub'		=> array ('S', 'P'),
+	'qty'			  => 1,
+	'cost'			  => 50000,
+	'icon'			  => 'olineman1',
+	'pos_id'          => 237
+);
+
 // New star players in BB16.
 $stars['Rasta Tailspike'] = array (
        'id'            => -62,

--- a/lib/game_data_lrb6x.php
+++ b/lib/game_data_lrb6x.php
@@ -127,7 +127,7 @@ $DEA['Chaos Pact'] = array (
     				'icon'			  => 'delfrenegade1',
     			    'pos_id'          => 213,
   			),
-  			'Chaos Troll'	=> array (
+			'Chaos Troll'	=> array (
     				'ma'        	=> 4,
     				'st'        	=> 5,
     				'ag'        	=> 1,

--- a/lib/misc_functions.php
+++ b/lib/misc_functions.php
@@ -245,7 +245,7 @@ function textdate($mysqldate, $noTime = false, $setSeconds = true) {
     $lng->getTrn('daysofweek/monday'),
     $lng->getTrn('daysofweek/tuesday'),
     $lng->getTrn('daysofweek/wednesday'),
-    $lng->getTrn('daysofweek/thusday'),
+    $lng->getTrn('daysofweek/thursday'),
     $lng->getTrn('daysofweek/friday'),
     $lng->getTrn('daysofweek/saturday'),
     );

--- a/modules/scheduler/class_scheduler.php
+++ b/modules/scheduler/class_scheduler.php
@@ -49,7 +49,7 @@ public static function main($argv) # argv = argument vector (array).
 		
 	?>
 	<div class="module_schedule">
-	<?
+	<?php 
 	self::inlineCSS();
 	
 	$step = 1;
@@ -67,7 +67,7 @@ public static function main($argv) # argv = argument vector (array).
 	
 	?>
 	</div>
-	<?
+	<?php 
 	return true;
 }
 
@@ -285,7 +285,7 @@ public static function inlineCSS() {
 	font-weight: bold;
   }
 </style>
-<?
+<?php 
 }
 
 /**
@@ -298,7 +298,7 @@ public static function step1() {
 	global $lng;
 	
 	?><div class="step1">
-	<h1><?php echo $lng->getTrn('scheduler_info', __CLASS__);?></h1><?
+	<h1><?php echo $lng->getTrn('scheduler_info', __CLASS__);?></h1><?php 
 	// Get all Leagues, div, tours 
 	$query = "SELECT leagues.lid,leagues.name as leaguename,leagues.tie_teams,divisions.did,divisions.name AS divisionsname,tours.tour_id,tours.name as toursname
 			FROM
@@ -365,31 +365,31 @@ public static function step1() {
 		
     }
 	
-	?></div><?
+	?></div><?php 
 }
 
 public static function openLeagueTag($id,$name) {
 	?>
-		<div class="league boxWide" id="lid_<? echo $id; ?>">
-			<div class="boxTitle1"><? echo $name; ?></div>
+		<div class="league boxWide" id="lid_<?php echo $id; ?>">
+			<div class="boxTitle1"><?php echo $name; ?></div>
 		<div class="boxBody">
-	<?
+	<?php 
 }
 
 public static function openDivisionTag($id,$name) {
 	?>
-		<div class="division boxWide" id="did_<? echo $id; ?>">
-			<div class="boxTitle3"><? echo $name; ?></div>
+		<div class="division boxWide" id="did_<?php echo $id; ?>">
+			<div class="boxTitle3"><?php echo $name; ?></div>
 			<div class="boxBody">
-	<?
+	<?php 
 }
 
 public static function openToursTag($id,$name) {
 	?>
-		<div class="tour boxWide" id="tour_<? echo $id; ?>">
-			<div class="tour_content boxTitle2"><h3><? echo $name; ?></h3></div>
+		<div class="tour boxWide" id="tour_<?php echo $id; ?>">
+			<div class="tour_content boxTitle2"><h3><?php echo $name; ?></h3></div>
 			<div class="boxBody">
-	<?
+	<?php 
 }
 
 public static function selectLink($tourid, $divid, $leagueid, $tie_teams) {
@@ -397,22 +397,22 @@ public static function selectLink($tourid, $divid, $leagueid, $tie_teams) {
 	
 	?>
 		<form method="post">
-			<input type="hidden" name="trid" value="<? echo $tourid ?>" />
-			<input type="hidden" name="did" value="<? echo $divid ?>" />
-			<input type="hidden" name="lid" value="<? echo $leagueid ?>" />
-			<input type="hidden" name="tie_teams" value="<? echo $tie_teams ?>" />
+			<input type="hidden" name="trid" value="<?php echo $tourid ?>" />
+			<input type="hidden" name="did" value="<?php echo $divid ?>" />
+			<input type="hidden" name="lid" value="<?php echo $leagueid ?>" />
+			<input type="hidden" name="tie_teams" value="<?php echo $tie_teams ?>" />
 			
 			<input type="hidden" name="step" value="2" />
 			<input type="submit" name="select" value="<?php echo $lng->getTrn('select', __CLASS__);?>" />
 		</form>
 	
-	<?
+	<?php 
 }
 
 public static function closeDiv() {
 	?>
 		</div>
-	<?
+	<?php 
 }
 
 public static function showTeamPoolForLeague($id, $showScheduleLink = false, $step) {
@@ -421,19 +421,19 @@ public static function showTeamPoolForLeague($id, $showScheduleLink = false, $st
 	?>
 		<div class="boxWide">
 			<div class="boxTitle4">
-				<h3><? echo $lng->getTrn('teampool', __CLASS__);?></h3>
+				<h3><?php echo $lng->getTrn('teampool', __CLASS__);?></h3>
 			</div>
 		<div class="boxBody">
 		
-		<? if ($step == 1) { ?>
-			<p><? echo $lng->getTrn('teampool_desc_step1_league', __CLASS__);?></p>
+		<?php if ($step == 1) { ?>
+			<p><?php echo $lng->getTrn('teampool_desc_step1_league', __CLASS__);?></p>
 			<div class="clear"></div>
-		<? } else if ($step==2) { ?>
-			<p><? echo $lng->getTrn('teampool_desc', __CLASS__);?></p>
+		<?php } else if ($step==2) { ?>
+			<p><?php echo $lng->getTrn('teampool_desc', __CLASS__);?></p>
 			<div class="clear"></div>
-		<? } 
+		<?php } 
 		
-		?><div class="teamPool"><?
+		?><div class="teamPool"><?php 
 			$query = "SELECT team_id from teams where f_lid = $id and f_did = 0";
 			
 			$result = mysql_query($query) or die(mysql_error());
@@ -446,7 +446,7 @@ public static function showTeamPoolForLeague($id, $showScheduleLink = false, $st
 					if ($seperator == 5) {
 						$seperator = 0;
 						?></div>
-						<div class="teamPool"><?
+						<div class="teamPool"><?php 
 					}
 				}
 			}
@@ -456,14 +456,14 @@ public static function showTeamPoolForLeague($id, $showScheduleLink = false, $st
 		
 		</div></div>
 		
-		<?
+		<?php 
 			if ($showScheduleLink) {
 				self::showScheduleTypeSelection();
 			}
 		?>
 
 
-	<?
+	<?php 
 }
 
 public static function showTeamPoolForDivision($id, $showScheduleLink = false, $step) {
@@ -471,18 +471,18 @@ public static function showTeamPoolForDivision($id, $showScheduleLink = false, $
 	?>
 		<div class="boxWide">
 			<div class="boxTitle4">
-				<h3><? echo $lng->getTrn('teampool', __CLASS__);?></h3>
+				<h3><?php echo $lng->getTrn('teampool', __CLASS__);?></h3>
 			</div>
 		<div class="boxBody">
 		
-		<? if ($step == 1) { ?>
-			<p><? echo $lng->getTrn('teampool_desc_step1_division', __CLASS__);?></p>
+		<?php if ($step == 1) { ?>
+			<p><?php echo $lng->getTrn('teampool_desc_step1_division', __CLASS__);?></p>
 			<div class="clear"></div>
-		<? } else if ($step==2) { ?>
-			<p><? echo $lng->getTrn('teampool_desc', __CLASS__);?></p>
+		<?php } else if ($step==2) { ?>
+			<p><?php echo $lng->getTrn('teampool_desc', __CLASS__);?></p>
 			<div class="clear"></div>
-		<? } 
-		?><div class="teamPool"><?
+		<?php } 
+		?><div class="teamPool"><?php 
 			$query = "SELECT team_id FROM teams WHERE f_did = " . $id . " ORDER by name";
 			
 			$result = mysql_query($query) or die(mysql_error());
@@ -495,7 +495,7 @@ public static function showTeamPoolForDivision($id, $showScheduleLink = false, $
 					if ($seperator == 5) {
 						$seperator = 0;
 						?></div>
-						<div class="teamPool"><?
+						<div class="teamPool"><?php 
 					}
 				}
 			}
@@ -504,12 +504,12 @@ public static function showTeamPoolForDivision($id, $showScheduleLink = false, $
 		<div class="clear"></div>
 		
 		</div></div>
-		<?
+		<?php 
 			if ($showScheduleLink) {
 				self::showScheduleTypeSelection();
 			}
 		?>
-	<?
+	<?php 
 }
 
 /**
@@ -532,11 +532,11 @@ public static function showTeam($id, $selectable = true, $dragable = false) {
 		$selectClass = "draggable";
 	}
 	?>
-	<div id="pool<?echo $id; ?>" class="team <? echo $selectClass; ?>">
+	<div id="pool<?echo $id; ?>" class="team <?php echo $selectClass; ?>">
 		<img border='0px' height='30' width='30' title='<?php echo $team->name;?>' alt='<?php echo $team->name;?>' src='<?php echo $teamLogo->getPath();?>'>
 		<span class="teamname"><?php echo $team->name;?></span>
 	</div>	
-	<?
+	<?php 
 }
 
 /**
@@ -547,21 +547,21 @@ public static function showScheduleTypeSelection() {
 	global $lng;
 ?>
 	<div class="boxWide">
-		<div class="boxTitle5"><? echo $lng->getTrn('available_schedulers', __CLASS__);?></h2></div>
+		<div class="boxTitle5"><?php echo $lng->getTrn('available_schedulers', __CLASS__);?></h2></div>
 		<div class="boxBody">
 			<div id="apaauto" class="schedulebutton">
-				<? echo $lng->getTrn('all_play_all_auto', __CLASS__);?>
+				<?php echo $lng->getTrn('all_play_all_auto', __CLASS__);?>
 			</div>
 			<div id="apamanual" class="schedulebutton">
-				<? echo $lng->getTrn('all_play_all_manual', __CLASS__);?>
+				<?php echo $lng->getTrn('all_play_all_manual', __CLASS__);?>
 			</div>
 			<div id="custom" class="schedulebutton">
-				<? echo $lng->getTrn('custom_schedule', __CLASS__);?>
+				<?php echo $lng->getTrn('custom_schedule', __CLASS__);?>
 			</div>
 			<div class="clear"></div>
 		</div>
 	</div>
-<?
+<?php 
 }
 
 /**
@@ -592,7 +592,7 @@ public static function apa_generate_draw() {
 	global $lng;
 	
 	?><div id="draw" class="boxWide">
-	<div class="boxTitle1"><? echo $lng->getTrn('draw', __CLASS__);?></div><?	
+	<div class="boxTitle1"><?php echo $lng->getTrn('draw', __CLASS__);?></div><?php 
 	$teams = json_decode($_POST['teams']);
 
 	$draw = array();
@@ -603,19 +603,19 @@ public static function apa_generate_draw() {
 	shuffle($draw);
 	?>
 	<div class="boxBody">
-	<?
+	<?php 
 	foreach($draw as $k => $v) {
 		?><div class="draw">
-		<?
+		<?php 
 		?><div class="slot">
 			<?echo chr(65 + $k);
-		?></div><?
+		?></div><?php 
 		self::showTeam($v, false);
-		?></div><?
-		?><div class="clear"></div><?
+		?></div><?php 
+		?><div class="clear"></div><?php 
 	}
 	
-	?></div></div><?
+	?></div></div><?php 
 	self::apa_generate_schedule($draw);
 }
 
@@ -634,19 +634,19 @@ public static function show_manual_draw() {
 	self::showTeamPoolForTeams($teamsClean);
 	
 	?><div id="draw" class="boxWide">
-	<div class="boxTitle1"><? echo $lng->getTrn('draw', __CLASS__);?></div><?	
+	<div class="boxTitle1"><?php echo $lng->getTrn('draw', __CLASS__);?></div><?php 
 	?>
 	<div class="boxBody">
-	<?
+	<?php 
 	foreach($teamsClean as $k => $v) {
 		?>
-		<div class="draw slot<? echo 65 + $k ?>">
+		<div class="draw slot<?php echo 65 + $k ?>">
 			<div class="slot">
 				<?echo chr(65 + $k);
-			?></div><?
-		?><div class="draw team droppable">Drag 'n' drop team here</div><?
-		?></div><?
-		?><div class="clear"></div><?
+			?></div><?php 
+		?><div class="draw team droppable">Drag 'n' drop team here</div><?php 
+		?></div><?php 
+		?><div class="clear"></div><?php 
 	}
 	
 	?>
@@ -654,7 +654,7 @@ public static function show_manual_draw() {
 	</div>
 	
 	
-	</div><?
+	</div><?php 
 
 }
 
@@ -674,29 +674,29 @@ public static function show_custom_draw() {
 	
 	?>
 	<div id="roundselection" class="boxWide">
-		<div class="boxTitle1"><? echo $lng->getTrn('roundselection', __CLASS__);?></div>
+		<div class="boxTitle1"><?php echo $lng->getTrn('roundselection', __CLASS__);?></div>
 		<div class="boxBody">
-	<?
+	<?php 
 	foreach (array(RT_FINAL => 'Final', RT_3RD_PLAYOFF => '3rd play-off', RT_SEMI => 'Semi final', RT_QUARTER => 'Quarter final', RT_ROUND16 => 'Round of 16 match') as $r => $d) {
-		?><div id="round_<? echo $r; ?>" class="roundPool notselected onoffsingletoggle"><?
+		?><div id="round_<?php echo $r; ?>" class="roundPool notselected onoffsingletoggle"><?php 
 		echo $d;
-		?></div><?
+		?></div><?php 
     }
 	
 	$pure_rounds = array(); 
 	
 	for ($i=1;$i<30;$i++) $pure_rounds[$i] = "Round #$i match";
 	foreach ($pure_rounds as $r => $d) {
-		?><div id="round_<? echo $r; ?>" class="roundPool notselected onoffsingletoggle"><?
+		?><div id="round_<?php echo $r; ?>" class="roundPool notselected onoffsingletoggle"><?php 
 		echo $d;
-		?></div><?
+		?></div><?php 
 	}
 
-	?><div class="clear"></div></div></div><?
+	?><div class="clear"></div></div></div><?php 
 	
 		?>
 	<div id="schedule" class="boxWide">
-		<div class="boxTitle1"><? echo $lng->getTrn('schedule', __CLASS__);?></div>
+		<div class="boxTitle1"><?php echo $lng->getTrn('schedule', __CLASS__);?></div>
 		<div class="boxBody">
 			<div id="selectedRound"></div>
 			<div id="hometeam">
@@ -706,15 +706,15 @@ public static function show_custom_draw() {
 			<div id="awayteam">
 				<div class="team awayteam">Click another team from the teampool as AWAY team</div>
 			</div>
-	<?
-	?><div class="clear"></div></div><?
+	<?php 
+	?><div class="clear"></div></div><?php 
 	
 	?><div id="log" class="boxWide">
-		<div class="boxTitle1"><? echo $lng->getTrn('log', __CLASS__);?></div>
+		<div class="boxTitle1"><?php echo $lng->getTrn('log', __CLASS__);?></div>
 		<div class="boxBody">
 			
-	<?
-	?><div class="clear"></div></div><?
+	<?php 
+	?><div class="clear"></div></div><?php 
 
 }
 
@@ -723,10 +723,10 @@ public static function showTeamPoolForTeams($teams) {
 	?>
 		<div class="boxWide">
 			<div class="boxTitle4">
-				<h3><? echo $lng->getTrn('teampool', __CLASS__);?></h3>
+				<h3><?php echo $lng->getTrn('teampool', __CLASS__);?></h3>
 			</div>
 		<div class="boxBody">
-		<div class="teamPool"><?
+		<div class="teamPool"><?php 
 			if(is_array($teams)) {
 				$seperator = 0;
 				foreach($teams as $teamid) {
@@ -737,7 +737,7 @@ public static function showTeamPoolForTeams($teams) {
 					if ($seperator == 4) {
 						$seperator = 0;
 						?></div>
-						<div class="teamPool"><?
+						<div class="teamPool"><?php 
 					}
 				}
 			}
@@ -746,7 +746,7 @@ public static function showTeamPoolForTeams($teams) {
 		<div class="clear"></div>
 		
 		</div></div>
-	<?
+	<?php 
 }
 
 /**
@@ -758,8 +758,8 @@ public static function apa_generate_schedule($draw) {
 	
 	?>
 	<div id="schedule" class="boxWide">
-		<div class="boxTitle1"><? echo $lng->getTrn('schedule', __CLASS__);?></div>
-	<?
+		<div class="boxTitle1"><?php echo $lng->getTrn('schedule', __CLASS__);?></div>
+	<?php 
 
 	$filename = './modules/scheduler/templates/apa_' . count($draw) . '.txt';
 
@@ -783,7 +783,7 @@ public static function apa_generate_schedule($draw) {
 	$cols = '4';
 	?>
 	<div class="boxBody">
-	<?
+	<?php 
 	echo "<table class='tours'>\n";
 	foreach($schedule as $rnd => $value) {
         $round = '';
@@ -812,7 +812,7 @@ public static function apa_generate_schedule($draw) {
             <td class="match" style="text-align: center;">-</td>
             <td class="match" style="text-align: left;"><?php echo $t2->name;?></td>
 
-			<?
+			<?php 
 				list($exitStatus, $mid) = Match::create(
 					array(
 						'team1_id' => $t1->team_id, 
@@ -822,7 +822,7 @@ public static function apa_generate_schedule($draw) {
 					)
 				);
 			?>
-				<? 
+				<?php 
 					if ($exitStatus == '') {
 						echo "<td class=\"success\">" . $lng->getTrn('schedule_successfull', __CLASS__). "</td>";
 					} else {
@@ -830,11 +830,11 @@ public static function apa_generate_schedule($draw) {
 					}
 				?>
 			</tr>
-			<?
+			<?php 
 		}
 	}
 	?></table>
-	</div></div><?
+	</div></div><?php 
 }
 
 public static function schedule_custom_game() {
@@ -876,10 +876,10 @@ public static function schedule_custom_game() {
 	}
 	
 	?>
-	<div class="<? echo $htmlclass; ?>">
-		<? echo $round ?> - <? echo $t1->name; ?> vs. <? echo $t2->name; ?> - <? echo $status; ?>
+	<div class="<?php echo $htmlclass; ?>">
+		<?php echo $round ?> - <?php echo $t1->name; ?> vs. <?php echo $t2->name; ?> - <?php echo $status; ?>
 	</div>
-	<?
+	<?php 
 	
 	
 }
@@ -1168,11 +1168,11 @@ $.fn.extend({
 		});
 	});
 </script>
-<? $t = (isset($_POST['trid'])) ? new Tour($_POST['trid']) : null; ?>
+<?php $t = (isset($_POST['trid'])) ? new Tour($_POST['trid']) : null; ?>
 
-<h1><?php echo $lng->getTrn('create_schedule', __CLASS__);?> <i><? echo $t->name; ?></i></h1>
+<h1><?php echo $lng->getTrn('create_schedule', __CLASS__);?> <i><?php echo $t->name; ?></i></h1>
 <div id="teamPool">
-<?
+<?php 
 	if ($_POST['tie_teams'] == 1) {
 		self::showTeamPoolForDivision($_POST['did'], true, 2);
 	} else if ($_POST['tie_teams'] == 0) {
@@ -1183,7 +1183,7 @@ $.fn.extend({
 	<div id="drawsched" style="display:none;">
 	</div>
 	
-	<?
+	<?php 
 }
 
 /*

--- a/modules/teamcreator/class_team_creator.php
+++ b/modules/teamcreator/class_team_creator.php
@@ -197,6 +197,7 @@ public static function getRaceArray() {
          }
          if (in_array($rid, $d['reduced_cost_races'])) {
             $inducement['cost'] = $d['reduced_cost'] / 1000;
+	 } else if ($d['cost'] < 1) {continue; /* eliminates negative value inducements to lock out of non-qualifying races */
          } else {
             $inducement['cost'] = $d['cost'] / 1000;
          }


### PR DESCRIPTION
With the original OBBLM code, an admin or league commissioner could create a team for a coach (from the coach's view), which can be useful sometime.

This is a workaround which calls the old new_team function when in coach view, so you can create again teams for other coaches as commissioner or admin, but won't have the new teamcreator when doing that.

A better solution would be to have teamcreator handle such creation.

I don't really expect this request to be pulled, but it will at least be available if other users wants it.
