### PR TITLE
Display available star players for race

### DIFF
--- a/lib/class_race_htmlout.php
+++ b/lib/class_race_htmlout.php
@@ -26,7 +26,8 @@ class Race_HTMLOUT extends Race
 
 public static function profile($rid) 
 {
-    global $lng, $DEA;
+    global $lng, $DEA, $stars;
+    
     $race = new Race($rid);
     $roster = $DEA[$race->name];
     title($lng->getTrn('race/'.strtolower(str_replace(' ','', $race->name))));
@@ -36,6 +37,8 @@ public static function profile($rid)
         <li><?php echo $lng->getTrn('common/reroll')?>: <?php echo $roster['other']['rr_cost']/1000;?>k</li>
     </ul><br>
     <?php
+
+    //List available player positions for race
     $players = array();
     foreach ($roster['players'] as $player => $d) {
         $p = (object) array_merge(array('position' => $player), $d);
@@ -46,26 +49,56 @@ public static function profile($rid)
         $players[] = $p;
     }
     $fields = array(
+        'qty'       => array('desc' => $lng->getTrn('common/maxqty')),
         'position'  => array('desc' => $lng->getTrn('common/pos')),
-        'pos_id'    => array('desc' => 'ID'),
-        'ma'        => array('desc' => 'Ma'),
-        'st'        => array('desc' => 'St'),
-        'ag'        => array('desc' => 'Ag'),
-        'av'        => array('desc' => 'Av'),
+        'ma'        => array('desc' => $lng->getTrn('common/ma')),
+        'st'        => array('desc' => $lng->getTrn('common/st')),
+        'ag'        => array('desc' => $lng->getTrn('common/ag')),
+        'av'        => array('desc' => $lng->getTrn('common/av')),
         'skills'    => array('desc' => $lng->getTrn('common/skills'), 'nosort' => true),
-        'N'         => array('desc' => 'Normal', 'nosort' => true),
-        'D'         => array('desc' => 'Double', 'nosort' => true),
+        'N'         => array('desc' => $lng->getTrn('common/normal'), 'nosort' => true),
+        'D'         => array('desc' => $lng->getTrn('common/double'), 'nosort' => true),
         'cost'      => array('desc' => $lng->getTrn('common/price'), 'kilo' => true, 'suffix' => 'k'),
-        'qty'       => array('desc' => 'Max. qty'),
     );
     HTMLOUT::sort_table(
-        'Roster',
+        $lng->getTrn('common/roster'),
         urlcompile(T_URL_PROFILE,T_OBJ_RACE,$race->race_id,false,false),
         $players,
         $fields,
         sort_rule('race_page'),
         (isset($_GET['sortpl'])) ? array((($_GET['dirpl'] == 'a') ? '+' : '-') . $_GET['sortpl']) : array(),
         array('GETsuffix' => 'pl', 'noHelp' => true, 'doNr' => false)
+    );
+
+    //List available star players for race
+    $racestars = array(); 
+ 
+    foreach ($stars as $s => $d) {  
+        if (in_array($race->race_id, $d['races'])) {
+            $tmp = new Star($d['id']);
+            $tmp->skills = skillsTrans($tmp->skills);            
+            $racestars[] = $tmp;
+        }
+    }
+        
+    $fields = array(
+		'name'   => array('desc' => $lng->getTrn('common/star'), 'href' => array('link' => urlcompile(T_URL_PROFILE,T_OBJ_STAR,false,false,false), 'field' => 'obj_id', 'value' => 'star_id')),
+        'ma'     => array('desc' => $lng->getTrn('common/ma')),
+        'st'     => array('desc' => $lng->getTrn('common/st')),
+        'ag'     => array('desc' => $lng->getTrn('common/ag')),
+        'av'     => array('desc' => $lng->getTrn('common/av')),
+        'skills' => array('desc' => $lng->getTrn('common/skills'), 'nosort' => true),
+        'cost'   => array('desc' => $lng->getTrn('common/price'), 'kilo' => true, 'suffix' => 'k'),
+    );
+        
+    HTMLOUT::sort_table(
+        $lng->getTrn('common/availablestars'),
+        urlcompile(T_URL_PROFILE,T_OBJ_RACE,$race->race_id,false,false),
+        $racestars,
+        $fields,
+        sort_rule('star'),
+        (isset($_GET['sort'])) ? array((($_GET['dir'] == 'a') ? '+' : '-') . $_GET['sort']) : array(),
+        array('anchor' => 's2', 'doNr' => false, 'noHelp' => true)
     );
 
     // Teams of the chosen race.


### PR DESCRIPTION
Add table to display availabe star players in race detail screen. 
Move remaining texts to text XML for ablility to translate (file now 100% free of texts).
Change order of columns in player positions to match rulebook (max. qty first) and better align with star player table.

Must go together with additions to translations.xml