### PR TITLE
Email validation

### DIFF
--- a/lib/class_email.php
+++ b/lib/class_email.php
@@ -19,14 +19,14 @@
 class Email {
     private static function checkEmail($email) {
         #'/^([.0-9a-z_-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' : 
-        #'/^([*+!.&#$¦\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' 
+        #'/^([*+!.&#$Â¦\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' 
 
         $status = true;
         $domain = '';
         if (strpos($email, '@')) 
             list($emailuser,$domain) = split("@",$email);
 
-        $emailexp = "/^([.0-9a-z_-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i";
+        $emailexp = "/^([.0-9a-z_\+-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,})$/i";
 
         if (!preg_match($emailexp, $email)) 
             $status = false;

--- a/modules/registration/class_registration.php
+++ b/modules/registration/class_registration.php
@@ -164,7 +164,7 @@ class Registration implements ModuleInterface
     public function chk_email() {
 
         #'/^([.0-9a-z_-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' : 
-        #'/^([*+!.&#$¦\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' 
+        #'/^([*+!.&#$Â¦\'\\%\/0-9a-z^_`{}=?~:-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i' 
 
         $status = true;
         $domain = '';
@@ -172,7 +172,7 @@ class Registration implements ModuleInterface
         $atpos = strpos($this->email, '@');
         if ( $atpos ) $domain = substr($this->email, $atpos + 1);
 
-        $emailexp = "/^([.0-9a-z_-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,4})$/i";
+        $emailexp = "/^([.0-9a-z_\+-]+)@(([0-9a-z-]+\.)+[0-9a-z]{2,})$/i";
 
         if ( !preg_match($emailexp, $this->email) ) $status = false;
 


### PR DESCRIPTION
allow addresses like name+test@domain.email

could be stricter on the allowance of dots and plusses, but for the sake of regex legibility I didnt go down that route.
