### PR TITLE
Docker support

### DIFF
--- a/install.php
+++ b/install.php
@@ -35,7 +35,7 @@ if (isset($_POST['setup']) || $argv[1] == 'setup') {
         echo <<<EOL
 <br><br>
 <b>What now?</b><br>
-&mdash; Please remove the <i>install.php</i> file from your OBBLM folder and <a href='index.php'>continue to the main page</a>.<br> 
+&mdash; Renaming the <i>install.php</i> file from your OBBLM folder. Please continue to <a href='index.php'>the main page</a>.<br>
 &mdash; Once at the main page login using the coach account 'root' with password 'root'<br>
 &mdash; From there you may enter the <i>administration</i> section and add new users (coaches) including changing the root password.<br>
 &mdash; For further help visit the <a href='$helpURL'>OBBLM wiki</a>.<br>
@@ -45,6 +45,8 @@ if (isset($_POST['setup']) || $argv[1] == 'setup') {
 EOL;
         echo "<br><br>";
         HTMLOUT::dnt();
+        // issue #213 - removing the install.php file to support docker
+        rename (getcwd()."/install.php", getcwd()."/install.php.rename");
     }
     else {
         echo "<br><b><font color='red'>Failed</font></b>";

--- a/modules/statsgraph/jpgraph/jpgraph.php
+++ b/modules/statsgraph/jpgraph/jpgraph.php
@@ -8,6 +8,13 @@
 // Copyright (c) Aditus Consulting. All rights reserved.
 //========================================================================
 
+# added to fix timezone issues when you may or may not have access to it in your php.ini file.
+#
+if( ! ini_get('date.timezone') )
+{
+    date_default_timezone_set('GMT');
+}
+
 require_once('jpg-config.inc.php');
 require_once('jpgraph_gradient.php');
 require_once('jpgraph_errhandler.inc.php');


### PR DESCRIPTION
Docker is becoming a very easy way to test/run code.  As a developer using docker I can spin up instances without having to install the various components.  With this, the applications need to be able to maintain themselves. For example, when naflm is started for the first time, the database is created and the admin needs to remove the install.php file.  Stuff like this should be automated to make installation fast and easy.