### PR TITLE
Only show available Starplayers for current roster

### DIFF
--- a/lib/class_match_htmlout.php
+++ b/lib/class_match_htmlout.php
@@ -721,7 +721,8 @@ class Match_HTMLOUT extends Match
 						<select id="stars_<?php echo $id;?>" <?php echo $DIS; ?>>
 							<?php
 							foreach ($stars as $s => $d) {
-								echo "<option ".((in_array($t->f_race_id, $d['races'])) ? 'style="background-color: '.COLOR_HTML_READY.';"' : '')." value='$d[id]'>$s</option>\n";
+                                if(in_array($t->f_race_id, $d['races']))
+                                    echo "<option ".((in_array($t->f_race_id, $d['races'])) ? 'style="background-color: '.COLOR_HTML_READY.';"' : '')." value='$d[id]'>$s</option>\n";
 							}
 							?>
 						</select>

--- a/modules/inducements/class_inducements.php
+++ b/modules/inducements/class_inducements.php
@@ -73,10 +73,12 @@ class IndcPage implements ModuleInterface
 
         $star_list[0] = '      <option value="0">-No Induced Stars-</option>' . "\n";
         foreach ($stars as $s => $d) {
-            if (in_array($d['id'], $starpairs)) // Hide Child Stars
-                $star_list[0] .= "      <option ".((in_array($t->f_race_id, $d['races'])) ? 'style="display: none; background-color: '.COLOR_HTML_READY.';" ' : '')."value=\"$d[id]\">$s</option>\n";
-            else
-                $star_list[0] .= "      <option ".((in_array($t->f_race_id, $d['races'])) ? 'style="background-color: '.COLOR_HTML_READY.';" ' : '')."value=\"$d[id]\">$s</option>\n";
+            if (in_array($t->f_race_id, $d['races'])) { // Only display available Stars
+                if (in_array($d['id'], $starpairs)) // Hide Child Stars
+                    $star_list[0] .= "      <option ".((in_array($t->f_race_id, $d['races'])) ? 'style="display: none; background-color: '.COLOR_HTML_READY.';" ' : '')."value=\"$d[id]\">$s</option>\n";
+                else
+                    $star_list[0] .= "      <option ".((in_array($t->f_race_id, $d['races'])) ? 'style="background-color: '.COLOR_HTML_READY.';" ' : '')."value=\"$d[id]\">$s</option>\n";
+            }
         }
 
 ?>


### PR DESCRIPTION
Both in inducement tryout and in match report, having the whole list of all starplayers is just useless, and the COLOR_HTML_READY does not render correctly on some situations (I don't know exactly when and why).

It is simplest to just only display allowed starplayers.
