### PR TITLE
fixed a division by zero

### DIFF
--- a/lib/class_sqlcore.php
+++ b/lib/class_sqlcore.php
@@ -665,7 +665,7 @@ class SQLCore
 				DETERMINISTIC
 				NO SQL
 			BEGIN
-				RETURN IFNULL(100*(won+draw/2)/played,0);
+				RETURN IF(played > 0,100*(won+draw/2)/played,0);
 			END',
 
 			/*


### PR DESCRIPTION
Happens  when some players exists in the DB with 0 matches played.
I don't really know if this worked before (maybe some older versions of mysql where IFNULL was enough ?), but it prevented syncAll() and especially syncAllMVs() to work on my instance (MariaDB 10.3.17, default version on Debian Buster).
