### PR TITLE
Strict standards message in class_player_htmlout.php #289

### DIFF
--- a/lib/class_player_htmlout.php
+++ b/lib/class_player_htmlout.php
@@ -86,7 +86,8 @@ class Player_HTMLOUT extends Player
 		title($p->name);
 		$players = $team->getPlayers();
 		$i = $next = $prev = 0;
-		$end = end(array_keys($players));
+		$playerArray = array_keys($players);
+		$end = end($playerArray);
 		foreach ($players as $player) {
 			if ($player->player_id == $p->player_id) {
 				if ($i == 0) {


### PR DESCRIPTION
When selecting a team, and pressing the 'i' link between the name and the postion, while it displays the result, the following error is also displayed:

Strict standards: Only variables should be passed by reference in D:\IdeaProjects\naflm\lib\class_player_htmlout.php on line 89
Call Stack

All work conducted by snotlingorc